### PR TITLE
Updated & fixed the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,20 @@ Download and compile the application
 	$ cd mongodb
 	$ make
 
-Then install them in your standard Erlang library location or include them in your path on startup
+Then you have two choices, either install them in your standard Erlang library location. To find the standard location, perform the following in erl:
 
-	$ erl -pa mongodb/ebin mongodb/deps/*/ebin
+	$ erl
+	1> code:lib_dir().
+	"/usr/local/Cellar/erlang/R15B/lib/erlang/lib"
+
+To copy the libraries:
+
+    $ mkdir <path from above>/mongodb-master
+    $ cp -R deps ebin <path from above>/mongodb-master/
+    
+
+Or alternatively you can include in your path on startup:
+
 	$ erl -pa ebin deps/*/ebin
 
 ### Starting


### PR DESCRIPTION
I fixed the repo url in the docs to point to the mongodb official one, rather than tonygen's.

I've fixed the paths for the include at startup - which were wrong (they included mongodb, which was the folder you were already in if following the instructions).

I've also put clear & simple instructions on how to install the library more permanently in to your standard Erlang library folder.

Hopefully this should make it easier for people not massively familiar with Erlang to play with!
