### PR TITLE
Redesign mongodb-erlang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ eunit:
 	@$(REBAR) eunit skip_deps=true
 
 ct:
-	@$(REBAR) ct skip_deps=true suites=gen_process
+	@$(REBAR) ct skip_deps=true
 
 # Dialyzer.
 build-plt:

--- a/src/mongo.erl
+++ b/src/mongo.erl
@@ -17,7 +17,8 @@
 	find/2,
 	find/3,
 	find/4,
-	find/5
+	find/5,
+	find/6
 ]).
 -export([
 	count/2,
@@ -146,7 +147,15 @@ find(Coll, Selector, Projector, Skip) ->
 %%      Empty projection means full projection.
 -spec find (collection(), selector(), projector(), skip(), batchsize()) -> cursor(). % Action
 find(Coll, Selector, Projector, Skip, BatchSize) ->
+	find(Coll, Selector, Projector, Skip, BatchSize, []).
+
+-spec find (collection(), selector(), projector(), skip(), batchsize(), [find_option()]) -> cursor(). % Action
+-type find_option() :: no_timeout | tail.
+find(Coll, Selector, Projector, Skip, BatchSize, Options) ->
 	read(#'query'{
+		tailablecursor = lists:member(tail, Options),
+		nocursortimeout = lists:member(no_timeout, Options),
+		awaitdata = lists:member(tail, Options),
 		collection = Coll,
 		selector = Selector,
 		projector = Projector,

--- a/src/mongo.erl
+++ b/src/mongo.erl
@@ -232,13 +232,12 @@ write(Request) ->
 		SafeMode ->
 			Params = case SafeMode of safe -> {}; {safe, Param} -> Param end,
 			Ack = write(Context#context.connection, Context#context.database, Request, Params),
-			case bson:lookup(err, Ack) of
-				{} -> ok;
-				{undefined} -> ok;
-				{String} ->
+			case bson:lookup(err, Ack, undefined) of
+				undefined -> ok;
+				String ->
 					case bson:at(code, Ack) of
-						10058 -> erlang:error(not_master);
-						Code -> erlang:error({write_failure, Code, String})
+						10058 -> erlang:exit(not_master);
+						Code -> erlang:exit({write_failure, Code, String})
 					end
 			end
 	end.

--- a/src/mongo.erl
+++ b/src/mongo.erl
@@ -28,6 +28,13 @@
 	command/1,
 	ensure_index/2
 ]).
+
+-export_type([
+	write_mode/0,
+	read_mode/0,
+	action/1
+]).
+
 % TODO: add auth/2
 
 -include("mongo_protocol.hrl").

--- a/src/mongo_cursor.erl
+++ b/src/mongo_cursor.erl
@@ -118,7 +118,7 @@ handle_call(rest, _From, State) ->
 
 handle_call({rest, Limit}, _From, State) ->
 	case rest_i(State, Limit) of
-		{Reply, #state{cursor = 0} = UpdatedState} ->
+		{Reply, #state{cursor = 0, batch = []} = UpdatedState} ->
 			{stop, normal, Reply, UpdatedState};
 		{Reply, UpdatedState} ->
 			{reply, Reply, UpdatedState}

--- a/src/mongo_cursor.erl
+++ b/src/mongo_cursor.erl
@@ -30,7 +30,7 @@
 	cursor      :: integer(),
 	batchsize   :: integer(),
 	batch       :: [bson:document()],
-	monitor     :: reference
+	monitor     :: reference()
 }).
 
 -include ("mongo_protocol.hrl").

--- a/src/mongo_pool.erl
+++ b/src/mongo_pool.erl
@@ -74,7 +74,7 @@ handle_info({'DOWN', Monitor, process, _Pid, _}, #state{monitors = Monitors} = S
 	{ok, Index} = orddict:find(Monitor, Monitors),
 	{noreply, State#state{
 		connections = array:set(Index, undefined, State#state.connections),
-		monitors = orddict:erase(Index, Monitors)
+		monitors = orddict:erase(Monitor, Monitors)
 	}};
 
 handle_info(_, State) ->

--- a/src/mongo_pool.erl
+++ b/src/mongo_pool.erl
@@ -42,7 +42,7 @@ init([Size, Sup]) ->
 	random:seed(erlang:now()),
 	{ok, #state{
 		supervisor = Sup,
-		connections = array:new(Size, [{fixed, false}, {default, undefined}]),
+		connections = array:new(Size, [{fixed, true}, {default, undefined}]),
 		monitors = orddict:new()
 	}}.
 

--- a/src/mongo_protocol.hrl
+++ b/src/mongo_protocol.hrl
@@ -40,7 +40,7 @@
 	selector :: selector(),
 	projector = [] :: projector() }).
 
--type projector() :: bson:document().
+-type projector() :: bson:document() | [].
 -type skip() :: integer().
 -type batchsize() :: integer(). % 0 = default batch size. negative closes cursor
 

--- a/src/mongo_protocol.hrl
+++ b/src/mongo_protocol.hrl
@@ -1,8 +1,12 @@
 % Wire protocol message types (records)
 
+-export_type([
+	collection/0
+]).
+
 -type db() :: atom().
 
--type collection() :: atom(). % without db prefix
+-type collection() :: mongo:collection(). % without db prefix
 
 -type cursorid() :: integer().
 

--- a/src/mongo_sup.erl
+++ b/src/mongo_sup.erl
@@ -20,7 +20,7 @@
 start_link() ->
 	supervisor:start_link({local, ?MODULE}, ?MODULE, app).
 
--spec start_cursor([term()]) -> pid().
+-spec start_cursor([term()]) -> {ok, pid()}.
 start_cursor(Args) ->
 	supervisor:start_child(mongo_cursors_sup, [Args]).
 

--- a/test/mongo_SUITE.erl
+++ b/test/mongo_SUITE.erl
@@ -73,7 +73,7 @@ insert_and_delete(Config) ->
 	Database   = ?config(database, Config),
 	Collection = ?config(collection, Config),
 	mongo:do(safe, master, Connection, Database, fun () ->
-		Teams = mongo:insert(Collection, [
+		_Teams = mongo:insert(Collection, [
 			{name, <<"Yankees">>, home, {city, <<"New York">>, state, <<"NY">>}, league, <<"American">>},
 			{name, <<"Mets">>, home, {city, <<"New York">>, state, <<"NY">>}, league, <<"National">>},
 			{name, <<"Phillies">>, home, {city, <<"Philadelphia">>, state, <<"PA">>}, league, <<"National">>},


### PR DESCRIPTION
Redesign mongodb-erlang into an OTP compliant application. This redesign is still work in progress, for example replica sets, ssl support and authentication are still missing. It also breaks the API in many places.