### PR TITLE
R16A compatibility

### DIFF
--- a/src/mongo.erl
+++ b/src/mongo.erl
@@ -391,9 +391,9 @@ binary_to_hexstr (Bin) ->
 -spec add_user (permission(), username(), password()) -> ok. % Action
 %@doc Add user with given access rights (permission)
 add_user (Permission, Username, Password) ->
-	User = case find_one (system.users, {user, Username}) of {} -> {user, Username}; {Doc} -> Doc end,
+	User = case find_one ('system.users', {user, Username}) of {} -> {user, Username}; {Doc} -> Doc end,
 	Rec = {readOnly, case Permission of read_only -> true; read_write -> false end, pwd, pw_hash (Username, Password)},
-	save (system.users, bson:merge (Rec, User)).
+	save ('system.users', bson:merge (Rec, User)).
 
 % Index %
 


### PR DESCRIPTION
Hello,

I've added single quotes around two atoms in mongo.erl because it fails compilation on R16A. It seems that this compiler version is stricter.

From the docs:

2.3  Atom

An atom is a literal, a constant with name. An atom should be enclosed in single quotes (') if it does not begin with a lower-case letter or if it contains other characters than alphanumeric characters, underscore (_), or @.
