### PR TITLE
Handle the new error code 16550 from mongoDB 2.4

### DIFF
--- a/src/mongo_query.erl
+++ b/src/mongo_query.erl
@@ -76,4 +76,5 @@ query_reply (#reply {
 			true -> case bson:at (code, hd (Docs)) of
 				13435 -> throw (not_master);
 				10057 -> throw (unauthorized);
+				16550 -> throw (unauthorized);
 				_ -> erlang:error ({bad_query, hd (Docs)}) end end.


### PR DESCRIPTION
After upgrading mongoDB to 2.4, whenever the database throws "assertion 16550 not authorized for query on db_name:collection_name", this driver returns bad_query instead of unauthorized for the caller to handle.

This patch captures error code 16550 and throws unauthorized.