### PR TITLE
Do not assume db and collection name is always atom. Allow binary.

### DIFF
--- a/src/mongo.erl
+++ b/src/mongo.erl
@@ -163,7 +163,7 @@ count(Coll, Selector) ->
 %     Ie. stops counting when max is reached to save processing time.
 -spec count(collection(), selector(), integer()) -> integer().
 count(Coll, Selector, Limit) ->
-	CollStr = atom_to_binary(Coll, utf8),
+	CollStr = mongo_protocol:value_to_binary(Coll, utf8),
 	Doc = command(case Limit =< 0 of
 		true -> {count, CollStr, 'query', Selector};
 		false -> {count, CollStr, 'query', Selector, limit, Limit}
@@ -210,18 +210,9 @@ assign_id(Doc) ->
 %% @private
 gen_index_name(KeyOrder) ->
 	bson:doc_foldl(fun(Label, Order, Acc) ->
-		<<Acc/binary, $_, (value_to_binary(Label))/binary, $_, (value_to_binary(Order))/binary>>
+		<<Acc/binary, $_, (mongo_protocol:value_to_binary(Label))/binary, $_, (mongo_protocol:value_to_binary(Order))/binary>>
 	end, <<"i">>, KeyOrder).
 
-%% @private
-value_to_binary(Value) when is_integer(Value) ->
-	bson:utf8(integer_to_list(Value));
-value_to_binary(Value) when is_atom(Value) ->
-	atom_to_binary(Value, utf8);
-value_to_binary(Value) when is_binary(Value) ->
-	Value;
-value_to_binary(_Value) ->
-	<<>>.
 
 %% @private
 write(Request) ->

--- a/src/mongo_pool.erl
+++ b/src/mongo_pool.erl
@@ -17,7 +17,7 @@
 
 -record(state, {
 	supervisor  :: pid(),
-	connections :: array(),
+	connections :: array:array(),
 	monitors    :: orddict:orddict()
 }).
 
@@ -39,7 +39,7 @@ get(Pool) ->
 
 %% @hidden
 init([Size, Sup]) ->
-	random:seed(erlang:now()),
+	random:seed(os:timestamp()),
 	{ok, #state{
 		supervisor = Sup,
 		connections = array:new(Size, [{fixed, false}, {default, undefined}]),

--- a/src/mongo_protocol.erl
+++ b/src/mongo_protocol.erl
@@ -2,7 +2,8 @@
 -export([
 	dbcoll/2,
 	put_message/3,
-	get_reply/1
+	get_reply/1,
+	value_to_binary/1, value_to_binary/2
 ]).
 -export_type([db/0]).
 -export_type([notice/0, request/0, reply/0]).
@@ -38,7 +39,7 @@
 
 -spec dbcoll (db(), collection()) -> bson:utf8().
 %@doc Concat db and collection name with period (.) in between
-dbcoll (Db, Coll) -> <<(atom_to_binary (Db, utf8)) /binary, $., (atom_to_binary (Coll, utf8)) /binary>>.
+dbcoll (Db, Coll) -> <<(value_to_binary (Db, utf8)) /binary, $., (value_to_binary (Coll, utf8)) /binary>>.
 
 -spec put_message(db(), message(), requestid()) -> binary().
 put_message(Db, #insert{collection = Coll, documents = Docs}, RequestId) ->
@@ -115,3 +116,15 @@ bit(true) -> 1.
 %% @private
 bool(0) -> false;
 bool(1) -> true.
+
+%% helper function
+value_to_binary(Value) when is_integer(Value) ->
+        bson:utf8(integer_to_list(Value));
+value_to_binary(Value) when is_atom(Value) ->
+        atom_to_binary(Value, utf8);
+value_to_binary(Value) when is_binary(Value) ->
+        Value;
+value_to_binary(_Value) ->
+        <<>>.
+value_to_binary(Value,utf8)->
+        value_to_binary(Value).


### PR DESCRIPTION
In the erlang world, binary is first class citizen and atom's do not
scale for database or table names.

Currently passing in collection or table as a binary crashes at
atom_to_binary. Hence changed this to value_to_binary which solves
the issue gracefully.