### PR TITLE
Fix timeout 

### DIFF
--- a/src/cursor/mc_cursor.erl
+++ b/src/cursor/mc_cursor.erl
@@ -157,7 +157,7 @@ next_i(#state{batch = []} = State) ->
 		collection = State#state.collection,
 		batchsize = State#state.batchsize,
 		cursorid = State#state.cursor
-	}),
+	}, infinity),
 	Cursor = Reply#reply.cursorid,
 	Batch = Reply#reply.documents,
 	next_i(State#state{cursor = Cursor, batch = Batch}).


### PR DESCRIPTION
Fix timeout when asking next elements over initial fecth on large collection. When iterating over a cursor, mongo reply on element 101 takes 6 seconds in our development environment.