### PR TITLE
Adding disconnect/1 to mongodb API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ use `mongo:connect/1,3,5,6`.
 
 `mongo:connect` returns `{error, Reason}` if it failed to connect.  
 `mongo:connect/1` takes only database as argument and connects to local database on 127.0.0.1:27017  
+`mongo:connect/2` same as `mongo:connect/1` with an additional argument - a proplist with connect options, such as host, port and register name.
 `mongo:connect/3` takes two additional params - login and password. It can be used to connect to local database and auth.  
 `mongo:connect/5` also takes extra params - they are write mode and read mode. They are `master` and `slave_ok` for read 
 and `unsafe`, `safe` and `{safe, bson:document()}` for write.  

--- a/src/api/mongo.erl
+++ b/src/api/mongo.erl
@@ -7,7 +7,8 @@
   connect/2,
   connect/3,
   connect/5,
-  connect/6,  %TODO disconnect?
+  connect/6,
+  disconnect/1,
   insert/3,
   update/4,
   update/5,
@@ -74,6 +75,10 @@ connect(Database, User, Pass, Wmode, Rmode, Opts) ->
       {w_mode, Wmode},
       {r_mode, Rmode}
     ])).
+
+-spec disconnect(pid()) -> ok.
+disconnect(Connection) ->
+  mc_worker:disconnect(Connection).
 
 %% @doc Insert a document or multiple documents into a collection.
 %%      Returns the document or documents with an auto-generated _id if missing.


### PR DESCRIPTION
Small pull request adding the disconnect ability to the API.
Comes handy when one connection is lost, it gives the ability to close others Connection in order to renew them.