### PR TITLE
fixed bson depedency (bson isn't app)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 {plugins, [rebar_ct]}.
 
 {deps, [
-  {bson, ".*", {git, "git://github.com/comtihon/bson-erlang", "master"}},
+  {bson, ".*", {git, "git://github.com/comtihon/bson-erlang", "master"}, [raw]},
   {pbkdf2, ".*", {git, "https://github.com/basho/erlang-pbkdf2.git", "master"}}
 ]}.
 

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -3,6 +3,6 @@
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
   {vsn, "2.0"},
   {registered, []},
-  {applications, [kernel, stdlib, bson, crypto]},
+  {applications, [kernel, stdlib, crypto]},
   {mod, {mongo_app, []}}
 ]}.


### PR DESCRIPTION
There is no app in bson repo, only bson module, so there is no need to load bson app. And also according to rebar documentation dependency without app inside should be declared with fourth param  - [raw]