### PR TITLE
Properly process mongodb getLastError response.

### DIFF
--- a/src/connection/mc_connection_man.erl
+++ b/src/connection/mc_connection_man.erl
@@ -38,7 +38,9 @@ reply(#reply{cursornotfound = false, queryerror = true} = Reply) ->
   [Doc | _] = Reply#reply.documents,
   process_error(bson:at(code, Doc), Doc);
 reply(#reply{cursornotfound = true, queryerror = false} = Reply) ->
-  erlang:error({bad_cursor, Reply#reply.cursorid}).
+  erlang:error({bad_cursor, Reply#reply.cursorid});
+reply({error, Error}) ->
+  process_error(error, Error).
 
 process_reply(Doc, Command) ->
   case bson:lookup(ok, Doc) of


### PR DESCRIPTION
Hi,

I noticed a problem when connecting in `safe` write mode and using an improper query. The error returned from the DB through `db.getLastError()`wasn't reaching the calling module, so I ended up processing it as a `bad_query` error.

Regards,