### PR TITLE
Update a full document

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 
 {deps, [
   {bson, ".*", {git, "git://github.com/comtihon/bson-erlang", "v0.2.2"}},
-  {pbkdf2, ".*", {git, "https://github.com/basho/erlang-pbkdf2.git", "master"}}
+  {pbkdf2, ".*", {git, "https://github.com/basho/erlang-pbkdf2.git", "2.0.0"}}
 ]}.
 
 {clean_files, [

--- a/src/api/mongo.erl
+++ b/src/api/mongo.erl
@@ -198,7 +198,7 @@ prepare_and_assign(Docs) when is_tuple(Docs) ->
     <<"$", _/binary>> -> Docs;  %command
     _ ->  %document
       case prepare_doc(Docs) of
-        Res when is_tuple(Res) -> [Res];
+        Res when is_tuple(Res) -> Res;
         List -> List
       end
   end;
@@ -207,13 +207,13 @@ prepare_and_assign(Doc) when is_map(Doc), map_size(Doc) == 1 ->
     [<<"$", _/binary>>] -> Doc; %command
     _ ->  %document
       case prepare_doc(Doc) of
-        Res when is_tuple(Res) -> [Res];
+        Res when is_tuple(Res) -> Res;
         List -> List
       end
   end;
 prepare_and_assign(Docs) ->
   case prepare_doc(Docs) of
-    Res when not is_list(Res) -> [Res];
+    Res when not is_list(Res) -> Res;
     List -> List
   end.
 

--- a/test/mongo_SUITE.erl
+++ b/test/mongo_SUITE.erl
@@ -51,8 +51,8 @@ init_per_testcase(Case, Config) ->
 
 end_per_testcase(_Case, Config) ->
   Connection = ?config(connection, Config),
-  Collection = ?config(collection, Config),
-  mongo:delete(Connection, Collection, {}).
+  Collection = ?config(collection, Config).
+  %mongo:delete(Connection, Collection, {}).
 
 %% Tests
 insert_and_find(Config) ->
@@ -202,6 +202,31 @@ update(Config) ->
     <<"details">> := #{<<"model">> := "14Q2", <<"make">> := "xyz"},
     <<"tags">> := ["apparel", "clothing"],
     <<"ratings">> := [#{<<"by">> := "ijk", <<"rating">> := 4}]} = Res,
+
+
+  %update full document
+  NewDoc =  {<<"_id">>, 100,
+        <<"sku">>, <<"abc123">>,
+        <<"quantity">>, 1000,
+        <<"instock">>, true,
+        <<"reorder">>, false,
+        <<"details">>, {<<"model">>, "14Q2", <<"make">>, "xyz"},
+        <<"tags">>, ["apparel", "clothing"],
+        <<"ratings">>, [{<<"by">>, "ijk", <<"rating">>, 4}]},
+  mongo:update(Connection, Collection, {<<"_id">>, 100},NewDoc),
+
+  %Check full document
+  [Res0] = find(Connection, Collection, {<<"_id">>, 100}),
+
+  #{<<"_id">> := 100,
+    <<"sku">> := <<"abc123">>,
+    <<"quantity">> := 1000,
+    <<"instock">> := true,
+    <<"reorder">> := false,
+    <<"details">> := #{<<"model">> := "14Q2", <<"make">> := "xyz"},
+    <<"tags">> := ["apparel", "clothing"],
+    <<"ratings">> := [#{<<"by">> := "ijk", <<"rating">> := 4}]} = Res0,
+
 
   %update existent fields
   Command = #{


### PR DESCRIPTION
MongoDB allows to update a document with a command or a doc:

http://docs.mongodb.org/manual/reference/method/db.collection.update/#replace-all-fields

In some version the driver lost this posibility.

The patch adds a solution for this problems.