### PR TITLE
fixed  dep path to pbkdf2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
   {bson, ".*",
    {git, "git://github.com/comtihon/bson-erlang", {tag, "v0.2.2"}}},
   {pbkdf2, ".*",
-   {git, "git@github.com:comtihon/erlang-pbkdf2.git", {tag, "2.0.0"}}},
+   {git, "git://github.com/comtihon/erlang-pbkdf2.git", {tag, "2.0.0"}}},
   {poolboy, ".*",
    {git, "git://github.com/devinus/poolboy.git", {tag, "1.5.1"}}}
 ]}.


### PR DESCRIPTION
Fixed bug -  failed to fetch and copy dep: {git,"git@github.com:comtihon/erlang-pbkdf2.git",
                                   {tag,"2.0.0"}}