### PR TITLE
Fix mc_cursor:foldl spec

### DIFF
--- a/src/cursor/mc_cursor.erl
+++ b/src/cursor/mc_cursor.erl
@@ -83,11 +83,11 @@ take(Cursor, Limit, Timeout) ->
 cursor_default_timeout() ->
   application:get_env(mongodb, cursor_timeout, infinity).
 
--spec foldl(fun((bson:document(), term()) -> term()), term(), pid(), non_neg_integer()) -> term().
+-spec foldl(fun((bson:document(), term()) -> term()), term(), pid(), non_neg_integer() | infinity) -> term().
 foldl(Fun, Acc, Cursor, Max) ->
   foldl(Fun, Acc, Cursor, Max, cursor_default_timeout()).
 
--spec foldl(fun((bson:document(), term()) -> term()), term(), pid(), non_neg_integer(), timeout()) -> term().
+-spec foldl(fun((bson:document(), term()) -> term()), term(), pid(), non_neg_integer() | infinity, timeout()) -> term().
 foldl(_Fun, Acc, _Cursor, 0, _Timeout) ->
   Acc;
 foldl(Fun, Acc, Cursor, infinity, Timeout) ->


### PR DESCRIPTION
The folds function spec should allow 'infinity' atom in _Max_ parameter. This change allows one to call fold function like:

```
mc_cursor:foldl(fun (X) -> ... end, [], Cursor, infinity).
```

Without proposed change dialyse is complaining when checking code using this library.
```
The call mc_cursor:foldl(fun((_,_) -> #{}), ~{}~, Cursor::pid(), 'infinity') will never return since the success typing is (fun((_,_) -> any()), any(), pid(), non_neg_integer()) -> any() and the contract is (fun((bson:document(),term()) -> term()), term(), pid(), non_neg_integer()) -> term()
```