### PR TITLE
Replace full document with bson object

### DIFF
--- a/src/api/mc_worker_api.erl
+++ b/src/api/mc_worker_api.erl
@@ -112,14 +112,30 @@ update(Connection, Coll, Selector, Doc) ->
 %% @doc Replace the document matching criteria entirely with the new Document.
 -spec update(pid(), collection(), selector(), map(), boolean(), boolean()) -> {boolean(), map()}.
 update(Connection, Coll, Selector, Doc, Upsert, MultiUpdate) ->
-  Converted = prepare(Doc, fun(D) -> D end),
+  ConvertFunction = fun(D)->
+    case is_tuple(D)of
+      true->
+        mc_utils:bson_to_map(D);
+      _->
+        D
+    end
+  end,
+  Converted = prepare(Doc, ConvertFunction),
   command(Connection, {<<"update">>, Coll, <<"updates">>,
     [#{<<"q">> => Selector, <<"u">> => Converted, <<"upsert">> => Upsert, <<"multi">> => MultiUpdate}]}).
 
 %% @doc Replace the document matching criteria entirely with the new Document.
 -spec update(pid(), collection(), selector(), map(), boolean(), boolean(), bson:document()) -> {boolean(), map()}.
 update(Connection, Coll, Selector, Doc, Upsert, MultiUpdate, WC) ->
-  Converted = prepare(Doc, fun(D) -> D end),
+  ConvertFunction = fun(D)->
+    case is_tuple(D)of
+      true->
+        mc_utils:bson_to_map(D);
+      _->
+        D
+    end
+  end,
+  Converted = prepare(Doc, ConvertFunction),
   command(Connection, {<<"update">>, Coll, <<"updates">>,
     [#{<<"q">> => Selector, <<"u">> => Converted, <<"upsert">> => Upsert, <<"multi">> => MultiUpdate}],
     <<"writeConcern">>, WC}).

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -25,7 +25,8 @@
   random_binary/1,
   hmac/2,
   is_proplist/1,
-  to_binary/1]).
+  to_binary/1,
+  bson_to_map/1]).
 
 get_value(Key, List) -> get_value(Key, List, undefined).
 
@@ -80,6 +81,11 @@ pw_hash(Username, Password) ->
 to_binary(Str) when is_list(Str) ->  list_to_binary(Str);
 to_binary(Str) when is_binary(Str) ->  Str.
 
+
+-spec bson_to_map(bson:document()) -> map().
+bson_to_map(Doc)->
+  Fun1= fun(K,V,Acc)-> maps:put(K,V,Acc) end,
+  bson:doc_foldl(Fun1,maps:new(),Doc).
 
 %% @private
 binary_to_hexstr(Bin) ->


### PR DESCRIPTION
If we use mc_worker_api:update with the following way: 

```
Database = <<"test">>.
{ok, Connection} = mc_worker_api:connect ([{database, Database}]).
Command =  {
<<"name">> , <<"Mets">>,
<<"quantity">>, 500,
<<"details">>, {<<"model">>, <<"14Q3">>, <<"make">>, <<"xyz">>},
<<"tags">>, [<<"coats">>, <<"outerwear">>, <<"clothing">>]
},
Collection= <<"test">>,
mc_worker_api:update(Connection, Collection, {<<"name">> , <<"Mets">>}, Command).

```

The returned of the execution will be: 

```
{false,#{<<"code">> => 9,
         <<"errmsg">> => <<"wrong type for 'u' field, expected object, found u: [ { name: \"Mets\", quantity: 500, details: { mode"...>>}}
```

The solution here to convert the Document to map, the update done properly. 
