### PR TITLE
Fix `selector` type spec

### DIFF
--- a/src/api/mc_worker_api.erl
+++ b/src/api/mc_worker_api.erl
@@ -37,7 +37,7 @@
 
 
 -type cursorid() :: integer().
--type selector() :: map().
+-type selector() :: bson:document() | map().
 -type projector() :: bson:document() | map().
 -type skip() :: integer().
 -type batchsize() :: integer(). % 0 = default batch size. negative closes cursor


### PR DESCRIPTION
The `selector` has to be a tuple in some cases, like when issuing
a `mapreduce` command.
