### PR TITLE
fix spec return type for `insert` and `find`

### DIFF
--- a/src/api/mc_worker_api.erl
+++ b/src/api/mc_worker_api.erl
@@ -48,11 +48,11 @@ disconnect(Connection) ->
 
 %% @doc Insert a document or multiple documents into a collection.
 %%      Returns the document or documents with an auto-generated _id if missing.
--spec insert(pid(), collection(), list() | map() | bson:document()) -> {{boolean(), map()}, list()}.
+-spec insert(pid(), collection(), list() | map() | bson:document()) -> {{boolean(), map()}, [map()] | map()}.
 insert(Connection, Coll, Docs) ->
   insert(Connection, Coll, Docs, {<<"w">>, 1}).
 
--spec insert(pid(), collection(), list() | map() | bson:document(), bson:document()) -> {{boolean(), map()}, list()}.
+-spec insert(pid(), collection(), list() | map() | bson:document(), bson:document()) -> {{boolean(), map()}, [map()] | map()}.
 insert(Connection, Coll, Doc, WC) when is_tuple(Doc); is_map(Doc) ->
   {Res, [UDoc | _]} = insert(Connection, Coll, [Doc], WC),
   {Res, UDoc};
@@ -154,6 +154,8 @@ find(Connection, Query) when is_record(Query, query) ->
   case mc_connection_man:read(Connection, Query) of
     [] -> [];
     Cursor when is_pid(Cursor) ->
+      {ok, Cursor};
+    {ok, Cursor}  ->
       {ok, Cursor}
   end.
 

--- a/src/connection/mc_connection_man.erl
+++ b/src/connection/mc_connection_man.erl
@@ -19,7 +19,7 @@
 -export([request_worker/2, process_reply/2]).
 -export([read/2, read_one/2, read_one_sync/4]).
 
--spec read(pid() | atom(), query()) -> [] | pid().
+-spec read(pid() | atom(), query()) -> [] | cursor().
 read(Connection, Request = #'query'{collection = Collection, batchsize = BatchSize}) ->
   case request_worker(Connection, Request) of
     {_, []} ->


### PR DESCRIPTION
fix spec return type that causes dialyzer error in erlang 19.3 for project using `mc_worker_api:find` and `mc_worker_api:insert`