### PR TITLE
Start with proc_lib instead of gen_server

### DIFF
--- a/src/connection/mc_cursor.erl
+++ b/src/connection/mc_cursor.erl
@@ -117,15 +117,14 @@ start_link(Connection, Collection, Cursor, BatchSize, Batch) ->
 %% @hidden
 init([Owner, Connection, Collection, Cursor, BatchSize, Batch]) ->
   Monitor = erlang:monitor(process, Owner),
-  proc_lib:init_ack({ok, self()}),
-  gen_server:enter_loop(?MODULE, [], #state{
-    connection = Connection,
-    collection = Collection,
-    cursor = Cursor,
-    batchsize = BatchSize,
-    batch = Batch,
-    monitor = Monitor
-  }).
+  {ok, #state{
+          connection = Connection,
+          collection = Collection,
+          cursor = Cursor,
+          batchsize = BatchSize,
+          batch = Batch,
+          monitor = Monitor
+         }}.
 
 %% @hidden
 handle_call({next, Timeout}, _From, State) ->


### PR DESCRIPTION
As proc_lib:init_ack/1 is used in init/1 proc_lib:start_link/3 should be
used to start the process as well to prevent spurious ack messages from
being sent to the parent process.