### PR TITLE
Add auth_source option

### DIFF
--- a/include/mongo_protocol.hrl
+++ b/include/mongo_protocol.hrl
@@ -57,9 +57,10 @@
 }).
 
 -record(conn_state, {
-  write_mode = unsafe :: mc_worker_api:write_mode(),
-  read_mode = master :: mc_worker_api:read_mode(),
-  database :: mc_worker_api:database()
+          write_mode = unsafe :: mc_worker_api:write_mode(),
+          read_mode = master :: mc_worker_api:read_mode(),
+          database :: mc_worker_api:database(),
+          auth_source :: mc_worker_api:database()
 }).
 -type conn_state() :: #conn_state{}.
 

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -215,8 +215,6 @@ get_set_opts_module(Options) ->
 auth_if_credentials(_, _, _, Login, Password) when Login =:= undefined; Password =:= undefined ->
   ok;
 auth_if_credentials(Socket, ConnState, NetModule, Login, Password) ->
-  % Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.database, NetModule),
-  % mc_auth_logic:auth(Version, Socket, ConnState#conn_state.database, Login, Password, NetModule),
   Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.auth_source, NetModule),
   mc_auth_logic:auth(Version, Socket, ConnState#conn_state.auth_source, Login, Password, NetModule),
   ok.

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -189,10 +189,11 @@ get_write_concern(_) -> undefined.
 %% @private
 %% Parses proplist to record
 form_state(Options) ->
-  Database = mc_utils:get_value(database, Options, <<"admin">>),
+    Database = mc_utils:get_value(database, Options, <<"admin">>),
+    AuthSource = mc_utils:get_value(auth_source, Options, <<"admin">>),
   RMode = mc_utils:get_value(r_mode, Options, master),
   WMode = mc_utils:get_value(w_mode, Options, unsafe),
-  #conn_state{database = Database, read_mode = RMode, write_mode = WMode}.
+  #conn_state{database = Database, auth_source = AuthSource, read_mode = RMode, write_mode = WMode}.
 
 %% @private
 %% Register this process if needed
@@ -214,6 +215,8 @@ get_set_opts_module(Options) ->
 auth_if_credentials(_, _, _, Login, Password) when Login =:= undefined; Password =:= undefined ->
   ok;
 auth_if_credentials(Socket, ConnState, NetModule, Login, Password) ->
-  Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.database, NetModule),
-  mc_auth_logic:auth(Version, Socket, ConnState#conn_state.database, Login, Password, NetModule),
+  % Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.database, NetModule),
+  % mc_auth_logic:auth(Version, Socket, ConnState#conn_state.database, Login, Password, NetModule),
+  Version = mc_worker_logic:get_version(Socket, ConnState#conn_state.auth_source, NetModule),
+  mc_auth_logic:auth(Version, Socket, ConnState#conn_state.auth_source, Login, Password, NetModule),
   ok.


### PR DESCRIPTION
This PR adds auth_source as a field in Worker Options, defaulting to 'admin' if not present. It performs authentication against the auth_source database following the normal MongoDB practice.