### PR TITLE
mc_worker_logic:make_request was being called with the wrong DB

### DIFF
--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -73,7 +73,7 @@ handle_call(CMD = #ensure_index{collection = Coll, index_spec = IndexSpec}, _, S
     mc_worker_logic:make_request(
       Socket,
       NetModule,
-      ConnState#conn_state.database,
+      DB,
       #insert{collection = mc_worker_logic:update_dbcoll(Coll, <<"system.indexes">>), documents = [Index]}),
   {reply, ok, State};
 handle_call(Request, From, State) when ?WRITE(Request) ->  % write requests (deprecated)


### PR DESCRIPTION
Although the code was properly figuring out the right DB, it would always pass the Connection DB to the make_request.