### PR TITLE
Update usage of `crypto:hmac` to avoid breaking in OTP 24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,16 @@ clean-docs:
 	rm -f doc/edoc-info
 
 # Tests.
-tests: clean app eunit ct
+tests: report-rebar3-version clean app eunit ct
 
 eunit:
 	./rebar3 eunit skip_deps=true
 
 ct: app
 	./rebar3 ct skip_deps=true
+
+report-rebar3-version:
+	@$(REBAR) version
 
 # Dialyzer.
 .$(PROJECT).plt: 
@@ -49,4 +52,4 @@ dialyze: .$(PROJECT).plt
 	@$(DIALYZER) -I include -I deps --src -r src --plt .$(PROJECT).plt --no_native \
 		-Werror_handling -Wrace_conditions -Wunmatched_returns
 
-.PHONY: deps clean-plt build-plt dialyze
+.PHONY: deps clean-plt build-plt dialyze report-rebar3-version

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ct: app
 	./rebar3 ct skip_deps=true
 
 report-rebar3-version:
-	@$(REBAR) version
+	./rebar3 version
 
 # Dialyzer.
 .$(PROJECT).plt: 

--- a/enot_config.json
+++ b/enot_config.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "app_vsn": "3.1.1",
+  "app_vsn": "3.1.2",
   "deps": [
     {
       "name": "bson",

--- a/enot_config.json
+++ b/enot_config.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "app_vsn": "3.1.2",
+  "app_vsn": "3.3.2",
   "deps": [
     {
       "name": "bson",

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.3.1"},
+  {vsn, "3.3.2"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -11,7 +11,7 @@
 
 -define(OLD_CRYPTO_API, true).
 -ifdef(OTP_RELEASE).
-  -if(?OTP_RELEASE >= 22).
+  -if(?OTP_RELEASE >= 23).
     -undef(OLD_CRYPTO_API).
   -endif.
 -endif.

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -9,14 +9,11 @@
 -module(mc_utils).
 -author("tihon").
 
+-define(OLD_CRYPTO_API, true).
 -ifdef(OTP_RELEASE).
   -if(?OTP_RELEASE >= 22).
-    -define(CRYPTO_API, new).
-  -else.
-    -define(CRYPTO_API, old).
+    -undef(OLD_CRYPTO_API).
   -endif.
--else.
-  -define(CRYPTO_API, old).
 -endif.
 
 %% API
@@ -72,10 +69,10 @@ get_timeout() ->
     undefined -> infinity
   end.
 
--if(?CRYPTO_API == new).
-hmac(One, Two) -> crypto:mac(hmac, sha, One, Two).
--elif(?CRYPTO_API == old).
+-ifdef(OLD_CRYPTO_API).
 hmac(One, Two) -> crypto:hmac(sha, One, Two).
+-else.
+hmac(One, Two) -> crypto:mac(hmac, sha, One, Two).
 -endif.
 
 pw_key(Nonce, Username, Password) ->

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -9,6 +9,16 @@
 -module(mc_utils).
 -author("tihon").
 
+-ifdef(OTP_RELEASE).
+  -if(?OTP_RELEASE >= 22).
+    -define(CRYPTO_API, new).
+  -else.
+    -define(CRYPTO_API, old).
+  -endif.
+-else.
+  -define(CRYPTO_API, old).
+-endif.
+
 %% API
 -export([
   get_value/2,
@@ -62,7 +72,11 @@ get_timeout() ->
     undefined -> infinity
   end.
 
+-if(?CRYPTO_API == new).
+hmac(One, Two) -> crypto:mac(hmac, sha, One, Two).
+-elif(?CRYPTO_API == old).
 hmac(One, Two) -> crypto:hmac(sha, One, Two).
+-endif.
 
 pw_key(Nonce, Username, Password) ->
   bson:utf8(binary_to_hexstr(crypto:hash(md5, [Nonce, Username, pw_hash(Username, Password)]))).


### PR DESCRIPTION
`crypto:hmac/3` is deprecated in OTP23 and will be removed in OTP24.
In this patch we're calling `crypto:mac/4` instead if supported by
the OTP release, gated by having `OTP_RELEASE` defined with a value
greater than or equal to `22`.

These updates also need to be applied to `pbkdf2`