### PR TITLE
Stop killing deleted connections in a replicaSet

### DIFF
--- a/enot_config.json
+++ b/enot_config.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "app_vsn": "3.3.3",
+  "app_vsn": "3.4.3",
   "deps": [
     {
       "name": "bson",

--- a/src/mongoc/mc_topology_logics.erl
+++ b/src/mongoc/mc_topology_logics.erl
@@ -22,7 +22,7 @@
 -export([update_topology_state/2, init_seeds/4, init_seeds/1]).
 
 update_topology_state(#mc_server{type = SType, pid = Pid}, State = #topology_state{type = sharded}) when ?NON_SHARDED(SType) -> %% SHARDED
-  exit(Pid, kill),
+  exit(Pid, normal),
   State;
 update_topology_state(_, State = #topology_state{type = sharded}) ->
   State;
@@ -33,7 +33,7 @@ update_topology_state(#mc_server{type = rsGhost}, State = #topology_state{type =
 update_topology_state(#mc_server{type = standalone}, State = #topology_state{type = unknown, seeds = Seeds}) when length(Seeds) =< 1 ->
   State#topology_state{type = standalone};
 update_topology_state(#mc_server{type = standalone, pid = Pid}, State = #topology_state{type = unknown}) ->
-  exit(Pid, kill),
+  exit(Pid, normal),
   State;
 update_topology_state(#mc_server{type = mongos}, State = #topology_state{type = unknown}) ->
   State#topology_state{type = sharded};
@@ -48,11 +48,11 @@ update_topology_state(
   set_possible_primary(Tab, Primary),
   State#topology_state{type = checkIfHasPrimary(Tab), setName = SetName};
 update_topology_state(#mc_server{type = SType, pid = Pid}, State = #topology_state{type = unknown}) when ?SEC_ARB_OTH(SType) ->
-  exit(Pid, kill),
+  exit(Pid, normal),
   State;
 update_topology_state(#mc_server{type = SType, pid = Pid},
     State = #topology_state{type = replicaSetNoPrimary}) when ?STAL_MONGS(SType) ->  %% REPLICASETNOPRIMARY
-  exit(Pid, kill),
+  exit(Pid, normal),
   State;
 update_topology_state(Server = #mc_server{type = SType, setName = SetName},
     State = #topology_state{type = replicaSetNoPrimary, setName = SetName}) when ?SEC_ARB_OTH(SType) ->
@@ -65,14 +65,14 @@ update_topology_state(
   set_possible_primary(Tab, Primary),
   State#topology_state{setName = SetName};
 update_topology_state(#mc_server{type = SType, pid = Pid}, State = #topology_state{type = replicaSetNoPrimary}) when ?SEC_ARB_OTH(SType) ->
-  exit(Pid, kill),
+  exit(Pid, normal),
   State;
 update_topology_state(#mc_server{type = SType},
     State = #topology_state{type = replicaSetWithPrimary, servers = Tab}) when ?UNKN_GHST(SType) -> %% REPLICASETWITHPRIMARY
   State#topology_state{type = checkIfHasPrimary(Tab)};
 update_topology_state(#mc_server{type = SType, pid = Pid},
     State = #topology_state{type = replicaSetWithPrimary, servers = Tab}) when ?STAL_MONGS(SType) ->
-  exit(Pid, kill),
+  exit(Pid, normal),
   State#topology_state{type = checkIfHasPrimary(Tab)};
 update_topology_state(
     #mc_server{type = SType, setName = SetName, primary = Primary},
@@ -82,7 +82,7 @@ update_topology_state(
 update_topology_state(
     #mc_server{type = SType, pid = Pid},
     State = #topology_state{type = replicaSetWithPrimary, servers = Tab}) when ?SEC_ARB_OTH(SType) ->
-  exit(Pid, kill),
+  exit(Pid, normal),
   State#topology_state{type = checkIfHasPrimary(Tab)};
 update_topology_state(Server = #mc_server{type = rsPrimary, setName = SetName}, State = #topology_state{setName = SetName}) -> %% REPLICASETWITHPRIMARY
   update_topology_state(Server, State#topology_state{setName = undefined});
@@ -100,7 +100,7 @@ update_topology_state(
 update_topology_state(#mc_server{type = rsPrimary, pid = Pid, host = Host, setName = SSetName},
     State = #topology_state{setName = CSetName, servers = Tab}) when SSetName =/= CSetName ->
   ets:insert(Tab, #mc_server{pid = Pid, host = Host, type = deleted}),
-  exit(Pid, kill),
+  exit(Pid, normal),
   State#topology_state{type = checkIfHasPrimary(Tab)};
 update_topology_state(_, State) ->
   State.

--- a/src/mongoc/mc_topology_logics.erl
+++ b/src/mongoc/mc_topology_logics.erl
@@ -154,7 +154,7 @@ stop_servers_not_in_list(HostsList, Tab) ->
         false ->
           ets:insert(Tab, E#mc_server{type = deleted}),
           unlink(E#mc_server.pid),
-          exit(E#mc_server.pid, kill),
+          exit(E#mc_server.pid, normal),
           [E#mc_server.host | Acc];
         true -> Acc
       end

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.3.3"},
+  {vsn, "3.4.3"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}


### PR DESCRIPTION
## Status

 - [x] Update version number and rebase against any latest updates in `master`
 - [x] Verify that changes from killing to shutting down don't break anything

Resolves #226

When stopping connections to "deleted" servers use `stop(Pid, normal)`
instead of `stop(Pid, kill)`, since killing crashes and will cascade
up to bring down the supervisor.

This behavior is reproducible when connecting to a replica set with a connection
string that doesn't match the hostname and port that Mongo sees for itself, such
as when running in a Docker environment.

As soon as `mc_monitor:check/2` reports the set of hosts for the replica set they
will come back different than what was used to connect, e.g. "mongo.localhost:27017"
vs. "localhost:27020" (if port-mapping is used with Docker), and so the driver will
think that the "localhost:27020" server was deleted from the cluster and then kill
the connections.

By not killing the connections the driver continues to operate stably.

❓ why are these connections being killed in the first place? would we really
want to crash the entire driver, connection pool, and database supervisor just because
the topology changed? (or in this case, was reporting differently than how we connected
to it in the first place)

❓ other responses in `mc_topology:update_topology_state/2` also kill their connections.
should those be updated to `stop(Pid, normal)` as well? is there a need to communicate
these shutdowns to the calling application? could that be done without a crash? (the crashes
not only take down the supervisor but also flood the system crash logs, as noted in #224 and #225)