### PR TITLE
Update `bson` dependency for latest updates

### DIFF
--- a/enot_config.json
+++ b/enot_config.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb",
-  "app_vsn": "3.4.3",
+  "app_vsn": "3.4.4",
   "deps": [
     {
       "name": "bson",

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {deps, [
   {bson, ".*",
-   {git, "git://github.com/comtihon/bson-erlang", {tag, "v0.2.2"}}},
+   {git, "git://github.com/comtihon/bson-erlang", {tag, "v0.2.4"}}},
   {pbkdf2, ".*",
    {git, "git://github.com/comtihon/erlang-pbkdf2.git", {tag, "2.0.1"}}},
   {poolboy, ".*",

--- a/src/mongodb.app.src
+++ b/src/mongodb.app.src
@@ -1,7 +1,7 @@
 %% ex: ts=4 sw=4 noexpandtab syntax=erlang
 {application, mongodb, [
   {description, "Client interface to MongoDB, also known as the driver. See www.mongodb.org"},
-  {vsn, "3.4.3"},
+  {vsn, "3.4.4"},
   {registered, []},
   {applications, [kernel, stdlib, bson, crypto, poolboy, pbkdf2]},
   {mod, {mongo_app, []}}


### PR DESCRIPTION
**On Hold** until `bson-erlang@0.2.4` is released, but I'm creating this PR in anticipation of that.

Updates `bson` to pull in:
 - fixes to match binary subtypes in bson spec
 - fixes type spec for `put_document` to allow maps