### PR TITLE
Updates to support MongoDB 5.1+

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   dialyzer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: erlang:24-slim
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
       - name: Cache PLTs
         id: cache-plts
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/rebar3/
           key: ${{ runner.os }}-erlang-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,37 +7,37 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        erlang: [22, 23]
+        erlang: [24, 25]
         mongodb: ["4.4.8", "5.0.2"]
     container:
       image: erlang:${{ matrix.erlang }}
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
       - run: ./scripts/install_mongo_debian.sh ${{ matrix.mongodb }}
       - run: ./scripts/start_mongo_single_node.sh
       - run: ./scripts/start_mongo_cluster.sh
       - run: ./rebar3 eunit
       - run: ./rebar3 ct
       - name: Archive Replica Set Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: mongodb_replica_set_logs
+          name: erlang-${{ matrix.erlang }}-mongodb-${{ matrix.mongodb }}-mongodb_replica_set_logs
           path: rs0-logs
           retention-days: 1
       - name: Archive Single Node Log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: single_node.log
+          name: erlang-${{ matrix.erlang }}-mongodb-${{ matrix.mongodb }}-single_node.log
           path: single_node.log
           retention-days: 1
       - name: CT Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ct_logs
+          name: erlang-${{ matrix.erlang }}-mongodb-${{ matrix.mongodb }}-ct_logs
           path: _build/test/logs/
           retention-days: 5

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   test_coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
-      image: erlang:23
+      image: erlang:24
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
       - run: ./scripts/install_mongo_debian.sh 5.0.2
       - run: ./scripts/start_mongo_single_node.sh
       - run: ./scripts/start_mongo_cluster.sh
@@ -19,27 +19,27 @@ jobs:
       - run: ./rebar3 ct --cover --cover_export_name ct.coverdata
       - run: rebar3 cover --verbose
       - name: Archive Replica Set Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: mongodb_replica_set_logs
           path: rs0-logs
           retention-days: 1
       - name: Archive Single Node Log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: single_node.log
           path: single_node.log
           retention-days: 1
       - name: Coverage Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Coverage Report
           path: _build/test/cover/
           retention-days: 5
       - name: CT Logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ct_logs
           path: _build/test/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ variables-ct*
 data
 _build
 .idea
+*.log
+rebar.lock
+*.crashdump
+*.plt

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ report-rebar3-version:
 
 # Dialyzer.
 .$(PROJECT).plt: 
-	@$(DIALYZER) --build_plt --output_plt .$(PROJECT).plt -r deps \
+	@$(DIALYZER) --build_plt --output_plt .$(PROJECT).plt -r _build/default/lib/ \
 		--apps erts kernel stdlib sasl inets crypto public_key ssl mnesia syntax_tools asn1
 
 clean-plt: 
@@ -48,8 +48,8 @@ clean-plt:
 
 build-plt: clean-plt .$(PROJECT).plt
 
-dialyze: .$(PROJECT).plt
-	@$(DIALYZER) -I include -I deps --src -r src --plt .$(PROJECT).plt --no_native \
-		-Werror_handling -Wrace_conditions -Wunmatched_returns
+dialyzer: .$(PROJECT).plt
+	@$(DIALYZER) -I include -I _build/default/lib/ --src -r src --plt .$(PROJECT).plt --no_native \
+		-Werror_handling -Wrace_conditions -Wunmatched_returns --get_warnings
 
-.PHONY: deps clean-plt build-plt dialyze report-rebar3-version
+.PHONY: deps clean-plt build-plt dialyzer report-rebar3-version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 This is the [MongoDB](https://www.mongodb.org/) driver for Erlang.
 
-[![Run tests](https://github.com/comtihon/mongodb-erlang/actions/workflows/test.yml/badge.svg)](https://github.com/comtihon/mongodb-erlang/actions/workflows/test.yml)
-[![Enot](https://enot.justtech.blog/badge?full_name=comtihon/mongodb-erlang)](https://enot.justtech.blog)
+[![Run tests](https://github.com/raxdcx/mongodb-erlang/actions/workflows/test.yml/badge.svg)](https://github.com/raxdcx/mongodb-erlang/actions/workflows/test.yml)
 
 ### Usage
 Add this repo as the dependency:

--- a/README.md
+++ b/README.md
@@ -42,9 +42,30 @@ If you are choosing between using
 [mongos](https://docs.mongodb.com/manual/reference/program/mongos/) and
 using mongo shard with `mongo_api` - prefer mongos and use `mc_worker_api`.
 
+In MongoDB 3.6, the `OP_MSG` and `OP_COMPRESSED` opcodes were added to the wired
+message protocol. `OP_MSG` was added to standardize the MongoDB message format,
+and `OP_COMPRESSED` takes things a step further by compressing the message to increase
+network efficiency. As of MongoDB 5.1, the old opcodes were deprecated, and all
+messages are sent with either `OP_MSG` or `OP_COMPRESSED`. 
+
+By default, this driver tries to automatically detect which MongoDB messaging protocol
+to use - the legacy one that existed before the `OP_MSG` opcode was introduced, or the
+modern messaging protocol based on `OP_MSG`. This is accomplished by setting the default
+value for the `use_legacy_protocol` env variable to `auto`. One can force the driver to
+use the legacy opcodes or the `OP_MSG`opcode by setting the application env
+`use_legacy_protocol` to `true` or `false` (for example by calling
+`application:set_env(mongodb, use_legacy_protocol, false)`).
+
+It's also possible to define the usage of legacy protocol on a per-connection basis.
+Simple pass `{use_legacy_protocol, false | true}` to mc_worker start options.
+
+As the `OP_MSG` opcode has existed in MongoDB since 3.6, and the driver defaults to auto-
+detecting which set of opcodes to use, ALL of the messages will be sent using the `OP_MSG`
+opcode if you are using a version for MongoDB greater 3.6 unless you explicitly set the
+`use_legacy_protocol` variable to `true`.
+
 mc_worker_api -- direct connection client
 ---------------------------------
-
 ### Connecting
 To connect to a database `test` on mongodb server listening on
 `localhost:27017` (or any address & port of your choosing)

--- a/include/mongo_protocol.hrl
+++ b/include/mongo_protocol.hrl
@@ -8,6 +8,7 @@
 -type colldb() :: collection() | {database(), collection()}.
 -type collection() :: binary() | atom(). % without db prefix
 -type database() :: binary() | atom().
+-type command() :: insert | update | delete.
 
 
 %% write
@@ -45,6 +46,24 @@
   projector = #{} :: mc_worker_api:projector()
 }).
 
+-record(op_msg_write_op, {
+  command :: command(),
+  collection :: colldb(),
+  database :: undefined | mc_worker_api:database(),
+  extra_fields = [] :: bson:document() | nonempty_list({binary(),any()}),
+  documents_name = <<"documents">> :: bson:utf8(),
+  documents = [] :: any()
+}).
+
+-record(op_msg_response, {
+  response_doc :: map()
+}).
+
+-record(op_msg_command, {
+  database :: undefined | mc_worker_api:database(),
+  command_doc :: bson:document() | nonempty_list({binary(),any()})
+}).
+
 -record(getmore, {
   collection :: colldb(),
   batchsize = 0 :: mc_worker_api:batchsize(),
@@ -73,9 +92,9 @@
 -record(reply, {
   cursornotfound :: boolean(),
   queryerror :: boolean(),
-  awaitcapable = false :: boolean(),
+  awaitcapable = false :: boolean() | undefined,
   cursorid :: mc_worker_api:cursorid(),
-  startingfrom = 0 :: integer(),
+  startingfrom = 0 :: integer() | undefined,
   documents :: [map()]
 }).
 -endif.

--- a/include/mongo_types.hrl
+++ b/include/mongo_types.hrl
@@ -31,11 +31,24 @@
 | {ssl, boolean()}
 | {ssl_opts, proplists:proplist()}
 | {register, atom() | fun()}.
+-type socket() :: gen_tcp:socket() | ssl:sslsocket().
 -type write_mode() :: unsafe | safe | {safe, bson:document()}.
 -type read_mode() :: master | slave_ok.
 -type service() :: {Host :: inet:hostname() | inet:ip_address(), Post :: 0..65535}.
 -type options() :: [option()].
 -type option() :: {timeout, timeout()} | {ssl, boolean()} | ssl | {database, database()} | {read_mode, read_mode()} | {write_mode, write_mode()}.
 -type cursor() :: pid().
--type query() :: #query{}.
+-type query() :: #'query'{}.
+-type op_msg_command() :: #op_msg_command{}.
+-type op_msg_write_op() :: #op_msg_write_op{}.
+-type op_msg_response() :: #op_msg_response{}.
+-type request() :: query()
+| op_msg_command()
+| op_msg_write_op()
+| #killcursor{}
+| #insert{}
+| #update{}
+| #delete{}
+| #getmore{}
+| #ensure_index{}.
 -endif.

--- a/include/mongoc.hrl
+++ b/include/mongoc.hrl
@@ -76,7 +76,7 @@
 | {password, binary()}
 | {w_mode, mc_worker_api:write_mode()}.
 -type readprefs() :: [readpref()].
--type readpref() :: #{rp_mode => readmode()}
+-type readpref() :: #{rp_mode => readmode()} | #{mode => binary()} | #{mode => binary(), tags => tuple()}
 |{rp_tags, [tuple()]}.
 -type reason() :: atom().
 

--- a/src/connection/mc_connection_man.erl
+++ b/src/connection/mc_connection_man.erl
@@ -12,28 +12,42 @@
 -include("mongo_types.hrl").
 -include("mongo_protocol.hrl").
 
+-dialyzer({no_fail_call, query_to_op_msg_cmd/2}).
+
 -define(NOT_MASTER_ERROR, 13435).
 -define(UNAUTHORIZED_ERROR(C), C =:= 10057; C =:= 16550).
 
 %% API
--export([request_worker/2]).
+-export([request_worker/2, process_reply/2]).
 -export([read/2, read/3, read_one/2]).
--export([command/2, command/3, database_command/3, database_command/4]).
+-export([op_msg/2, op_msg_read_one/2, op_msg_raw_result/2]).
+-export([command/2, command/3, database_command/3, database_command/4, request_raw_no_parse/4]).
 
 -spec read(pid() | atom(), query()) -> [] | {ok, pid()}.
 read(Connection, Request) -> read(Connection, Request, undefined).
 
--spec read(pid() | atom(), query(), undefined | mc_worker_api:batchsize()) -> [] | {ok, pid()}.
+-spec read(pid() | atom(), query() | op_msg_command(), undefined | mc_worker_api:batchsize()) -> [] | {ok, pid()}.
 read(Connection, Request = #'query'{collection = Collection, batchsize = BatchSize, database = DB}, CmdBatchSize) ->
+  read(Connection, Request, Collection, select_batchsize(CmdBatchSize, BatchSize), DB);
+read(Connection, Request = #'op_msg_command'{database = DB, command_doc = ([{_, Collection} | _ ] = Fields)},
+    _CmdBatchSize)  ->
+  BatchSize = case lists:keyfind(<<"batchSize">>, 1, Fields) of
+    {_, Size} -> Size;
+    false -> 101
+  end,
+  read(Connection, Request, Collection, BatchSize, DB).
+
+read(Connection, Request, Collection, BatchSize, DB) ->
   case request_worker(Connection, Request) of
     {_, []} ->
       [];
     {Cursor, Batch} ->
-      mc_cursor:start_link(Connection, Collection, Cursor, select_batchsize(CmdBatchSize, BatchSize), Batch, DB)
+      mc_cursor:start_link(Connection, Collection, Cursor, BatchSize, Batch, DB);
+    X ->
+      erlang:error({error_unexpected_response, X})
   end.
-  
 
--spec read_one(pid() | atom(), query()) -> undefined | map().
+-spec read_one(pid() | atom(), request()) -> undefined | map().
 read_one(Connection, Request) ->
   {0, Docs} = request_worker(Connection, Request#'query'{batchsize = -1}),
   case Docs of
@@ -41,24 +55,51 @@ read_one(Connection, Request) ->
     [Doc | _] -> Doc
   end.
 
+-spec command(pid(), mc_worker_api:selector()) -> {boolean(), map()}.
 command(Connection, Query = #query{selector = Cmd}) ->
+  QueryOrOpMsg = query_to_op_msg_cmd(mc_utils:use_legacy_protocol(Connection), Query),
   case determine_cursor(Cmd) of
     false ->
-      Doc = read_one(Connection, Query),
-      process_reply(Doc, Query);
+      legacy_command(mc_utils:use_legacy_protocol(Connection), Connection, QueryOrOpMsg);
     BatchSize ->
-      case read(Connection, Query#query{batchsize = -1}, BatchSize) of
+      case read(Connection, QueryOrOpMsg, BatchSize) of
         [] -> [];
         {ok, Cursor} when is_pid(Cursor) ->
           {ok, Cursor}
       end
   end;
-command(Connection, Command) when not is_record(Command, query)->
+command(Connection, Command) when not is_record(Command, query) ->
   command(Connection,
     #'query'{
       collection = <<"$cmd">>,
       selector = Command
     }).
+
+legacy_command(true, Connection, Query) ->
+  Doc = read_one(Connection, Query),
+  process_reply(Doc, Query);
+legacy_command(false, Connection, OpMsg) ->
+  {true, mc_connection_man:op_msg_raw_result(Connection, OpMsg)}.
+
+-spec query_to_op_msg_cmd(boolean(), mc_worker_api:selector() ) -> query() | op_msg_command().
+query_to_op_msg_cmd(true, Query) ->
+  Query#query{batchsize = -1};
+query_to_op_msg_cmd(false, Query) ->
+  #query{database = DB, slaveok = SlaveOk, selector = Selector} = Query,
+  Fields = bson:fields(Selector),
+  NewSelector =
+    case {lists:keyfind(<<"$readPreference">>, 1, Fields), SlaveOk} of
+      {{<<"$readPreference">>, _}, _} -> Selector;
+      {false, true} ->
+        bson:merge(Fields, {<<"$readPreference">>, #{<<"mode">> => <<"primaryPreferred">>}});
+      {false, false} ->
+        %% primary is the default mode so we do not need to change anything
+        Fields
+    end,
+  #'op_msg_command'{
+    database = DB,
+    command_doc = NewSelector
+  }.
 
 command(Connection, Command, _IsSlaveOk = true) ->
   command(Connection,
@@ -90,7 +131,7 @@ database_command(Connection, Database, Command, IsSlaveOk) ->
     },
     IsSlaveOk).
 
--spec request_worker(pid(), mongo_protocol:message()) -> ok | {non_neg_integer(), [map()]}.
+-spec request_worker(pid(), mongo_protocol:message()) -> ok | {non_neg_integer(), [map()]} | map().
 request_worker(Connection, Request) ->  %request to worker
   Timeout = mc_utils:get_timeout(),
   reply(gen_server:call(Connection, Request, Timeout)).
@@ -101,6 +142,64 @@ process_reply(Doc = #{<<"ok">> := N}, _) when is_number(N) ->   %command succeed
 process_reply(Doc, Command) -> %unknown result
   erlang:error({bad_command, Doc}, [Command]).
 
+op_msg(Connection, OpMsg) ->
+  Doc = request_worker(Connection, OpMsg),
+  process_reply(Doc, OpMsg).
+
+op_msg_read_one(Connection, OpMsg) ->
+  Timeout = mc_utils:get_timeout(),
+  Response = gen_server:call(Connection, OpMsg, Timeout),
+  case Response of
+    #op_msg_response{response_doc =
+    #{<<"ok">> := 1.0,
+      <<"cursor">>:=
+      #{<<"firstBatch">>:=[Doc],
+        <<"id">>:=0}
+    }} ->
+      Doc;
+    #op_msg_response{response_doc =
+    #{<<"ok">> := 1.0}} ->
+      undefined;
+    #op_msg_response{response_doc = Doc} ->
+      erlang:error({error, Doc});
+    _ ->
+      erlang:error({error_unexpected_response, Response})
+  end.
+
+op_msg_raw_result(Connection, OpMsg) ->
+  Timeout = mc_utils:get_timeout(),
+  FromServer = gen_server:call(Connection, OpMsg, Timeout),
+  case FromServer of
+    #op_msg_response{response_doc =
+    (#{<<"ok">> := 1.0} = Res)} ->
+      Res;
+    _ ->
+      erlang:error({error, FromServer})
+  end.
+
+request_raw_no_parse(Socket, Database, Request, NetModule) ->
+  Timeout = mc_utils:get_timeout(),
+  ok = set_opts(Socket, NetModule, false),
+  {ok, _, _} = mc_worker_logic:make_request(Socket, NetModule, Database, Request),
+  Result = recv_all(Socket, Timeout, NetModule),
+  ok = set_opts(Socket, NetModule, true),
+  Result.
+
+%% @private
+set_opts(Socket, ssl, Value) ->
+  ssl:setopts(Socket, [{active, Value}]);
+set_opts(Socket, gen_tcp, Value) ->
+  inet:setopts(Socket, [{active, Value}]).
+
+%% @private
+recv_all(Socket, Timeout, NetModule) ->
+  recv_all(Socket, Timeout, NetModule, <<>>).
+recv_all(Socket, Timeout, NetModule, Rest) ->
+  {ok, Packet} = NetModule:recv(Socket, 0, Timeout),
+  case mc_worker_logic:decode_responses(<<Rest/binary, Packet/binary>>) of
+    {[], Unfinished} -> recv_all(Socket, Timeout, NetModule, Unfinished);
+    {Responses, _} -> Responses
+  end.
 
 %% @private
 reply(ok) -> ok;
@@ -112,7 +211,14 @@ reply(#reply{cursornotfound = false, queryerror = true} = Reply) ->
 reply(#reply{cursornotfound = true, queryerror = false} = Reply) ->
   erlang:error({bad_cursor, Reply#reply.cursorid});
 reply({error, Error}) ->
-  process_error(error, Error).
+  process_error(error, Error);
+reply(#op_msg_response{response_doc = (#{<<"cursor">> := #{<<"firstBatch">> := Batch, <<"id">> := Id}} = Doc)}) when
+  map_get(<<"ok">>, Doc) == 1 ->
+  {Id, Batch};
+reply(#op_msg_response{response_doc = Document}) when map_get(<<"ok">>, Document) == 1 ->
+  Document;
+reply(Resp) ->
+  erlang:error({error_cannot_parse_response, Resp}).
 
 %% @private
 -spec process_error(atom() | integer(), term()) -> no_return().

--- a/src/main/mc_super_sup.erl
+++ b/src/main/mc_super_sup.erl
@@ -17,4 +17,5 @@ start_link() ->
 init(app) ->
 	MongoIdServer = ?CHILD(mongo_id_server, worker),
 	McPoolSup = ?CHILD(mc_pool_sup, supervisor),
-	{ok, {{one_for_one, 1000, 3600}, [MongoIdServer, McPoolSup]}}.
+	PIDInfoServer = ?CHILD(mc_worker_pid_info, worker),
+	{ok, {{one_for_one, 1000, 3600}, [MongoIdServer, McPoolSup, PIDInfoServer]}}.

--- a/src/main/mc_worker_pid_info.erl
+++ b/src/main/mc_worker_pid_info.erl
@@ -1,0 +1,136 @@
+-module(mc_worker_pid_info).
+
+%% This module is used to get information (currently only the protocol type)
+%% ragaring mc_worker processes. This is useful so we can encode messages in
+%% the right way befor sending them to an mc_worker process.
+
+-behaviour(gen_server).
+
+-include("mongo_protocol.hrl").
+
+-export([start_link/0,
+  init/1,
+  terminate/2,
+  handle_cast/2,
+  handle_call/3,
+  get_info/1,
+  set_info/2,
+  discard_info/1,
+  get_protocol_type/1,
+  handle_info/2,
+  install_mc_worker_info/4]).
+
+-dialyzer({no_fail_call, detect_protocol_type/4}).
+
+-define(CLEAN_TABLE_PERIOD_MINS, 30).
+-define(CLEAN_TABLE_MESSAGE, clean_table).
+-define(MC_WORKER_PID_INFO_TAB_NAME, mc_worker_pid_info_tab).
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+init(_) ->
+  ets:new(?MC_WORKER_PID_INFO_TAB_NAME, [public, named_table, {read_concurrency, true}]),
+  {ok, start_cleanup_timer_update_state(#{})}.
+
+start_cleanup_timer_update_state(State) ->
+  State#{
+    cleanup_timer_ref =>
+    erlang:start_timer(timer:minutes(?CLEAN_TABLE_PERIOD_MINS),
+      self(),
+      ?CLEAN_TABLE_MESSAGE,
+      [])
+  }.
+
+terminate(_,_) ->
+  ets:delete(?MC_WORKER_PID_INFO_TAB_NAME).
+
+%% These functions does not do anything as this server is just a holder of an ETS table
+handle_cast(_Request, State) -> {noreply, State}.
+handle_call(_Request, _From, State) -> {reply, {error, ignore}, State}.
+
+handle_info({timeout,
+  TimerRef,
+  ?CLEAN_TABLE_MESSAGE},
+    #{cleanup_timer_ref := TimerRef} = State) ->
+  PidInfos = ets:tab2list(?MC_WORKER_PID_INFO_TAB_NAME),
+  [delete_pid_if_dead(Pid) || {Pid, _} <- PidInfos],
+  {noreply, start_cleanup_timer_update_state(State)};
+handle_info(_, State) ->
+  {noreply, State}.
+
+delete_pid_if_dead(Pid) ->
+  case erlang:is_process_alive(Pid) of
+    true -> ok;
+    false -> ets:delete(?MC_WORKER_PID_INFO_TAB_NAME, Pid)
+  end.
+
+get_info(MCWorkerPID) ->
+  try
+    case ets:lookup(?MC_WORKER_PID_INFO_TAB_NAME, MCWorkerPID) of
+      [{MCWorkerPID, InfoMap}] ->
+        {ok, InfoMap};
+      [] ->
+        not_found
+    end
+  catch
+    _:_:_ ->
+      not_found
+  end.
+
+
+set_info(MCWorkerPID, InfoMap) ->
+  ets:insert(?MC_WORKER_PID_INFO_TAB_NAME, {MCWorkerPID, InfoMap}).
+
+discard_info(MCWorkerPID) ->
+  ets:delete(?MC_WORKER_PID_INFO_TAB_NAME, MCWorkerPID).
+
+get_protocol_type(MCWorkerPID) ->
+  case get_info(MCWorkerPID) of
+    {ok, #{protocol_type := ProtocolType}} ->
+      ProtocolType;
+    _ ->
+      %% Not found means that this library has been hot upgraded and the
+      %% mc_worker process was created before the hot_upgrade so we use
+      %% the legacy protocol as this was what existed before
+      legacy
+  end.
+
+%% This process should be called from mc_worker processes to install their info
+%% in the ?MC_WORKER_PID_INFO_TAB_NAME ETS table
+install_mc_worker_info(Options, NetModule, Database, Opts) ->
+  UseLegacyProtocol = maps:get(use_legacy_protocol, Opts),
+  try
+    ProtocolType = detect_protocol_type(UseLegacyProtocol, Options, NetModule, Database),
+    mc_worker_pid_info:set_info(self(), #{protocol_type => ProtocolType}),
+    ok
+  catch
+    What:Reason ->
+      {error, {What, Reason}}
+  end.
+
+%% true - use the legacy message protocol
+%% false - use the modern message protocol based on the op_msg opcode
+%% auto - detect which message protocol to use based on the database
+detect_protocol_type(true, _ConnectionOpts, _NetModule, _Database)  -> legacy;
+detect_protocol_type(false, _ConnectionOpts, _NetModule, _Database) -> op_msg;
+detect_protocol_type(auto, ConnectionOpts, NetModule, Database) ->
+  %% Automatically detect which protocol to use. We send a `hello' command using
+  %% the new protocol. If we have our connection closed by the server, it means
+  %% it doesn't support the new protocol.
+  %% See also:
+  %% * https://github.com/mongodb/mongo/blob/5e494138af456f42381ad08748cc7fbc4ace7a60/src/mongo/base/error_codes.yml
+  %% * https://www.mongodb.com/docs/manual/reference/command/hello/#mongodb-dbcommand-dbcmd.hello
+  %% * https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/#std-label-wire-op-msg
+  {ok, Socket} = mc_worker_logic:connect(ConnectionOpts),
+  Command = bson:fields({hello, 1}),
+  Request = #op_msg_command{command_doc = Command, database = Database},
+  try mc_connection_man:request_raw_no_parse(Socket, Database, Request, NetModule) of
+    [{_, #op_msg_response{response_doc = #{<<"ok">> := _}}} | _] -> op_msg;
+    _ErrorResponse -> legacy
+  catch
+    _:_ -> legacy
+  after
+    NetModule:close(Socket)
+  end.

--- a/src/mongoc/mc_monitor.erl
+++ b/src/mongoc/mc_monitor.erl
@@ -153,10 +153,15 @@ maybe_recheck(_, Topology, Server, ConnectArgs, HB_MS, MinHB_MS) ->
 check(ConnectArgs, Server) ->
   Start = os:timestamp(),
   {ok, Conn} = mc_worker_api:connect(ConnectArgs),
-  {true, IsMaster} = mc_worker_api:command(Conn, {isMaster, 1}),
+  {true, IsMaster} = is_master_check(mc_utils:use_legacy_protocol(Conn), Conn),
   Finish = os:timestamp(),
   mc_worker_api:disconnect(Conn),
   {monitor_ismaster, Server, IsMaster, timer:now_diff(Finish, Start)}.
+
+is_master_check(true, Connection) ->
+  mc_worker_api:command(Connection, {isMaster, 1});
+is_master_check(false, Connection) ->
+  mc_worker_api:command(Connection, {hello, 1}).
 
 %% @private
 do_timeout(Pid, TO) when TO > 0 ->

--- a/src/support/mc_utils.erl
+++ b/src/support/mc_utils.erl
@@ -31,7 +31,9 @@
   hmac/2,
   is_proplist/1,
   to_binary/1,
-  get_srv_seeds/1]).
+  get_srv_seeds/1,
+  use_legacy_protocol/1,
+  get_connection_pid/1]).
 
 get_value(Key, List) -> get_value(Key, List, undefined).
 
@@ -122,3 +124,18 @@ valid_endpoint(Host, Srv) ->
   [_ | HostBaseDomain] = string:split(Host, "."),
   [_ | SrvBaseDomain] = string:split(Srv, "."),
   HostBaseDomain == SrvBaseDomain.
+
+use_legacy_protocol(Connection) ->
+  %% Latest MongoDB version that supported the non-op-msg based opcodes was
+  %% 5.0.x (at the time of writing 5.0.14). The non-op-msg based opcodes were
+  %% removed in MongoDB version 5.1.0. See
+  %% https://www.mongodb.com/docs/manual/legacy-opcodes/
+  case mc_worker_pid_info:get_protocol_type(Connection) of
+    legacy -> true;
+    op_msg -> false
+  end.
+
+get_connection_pid(Connection) when is_pid(Connection) ->
+  Connection;
+get_connection_pid(#{connection_pid := Pid}) ->
+  Pid.

--- a/test/mc_test_utils.erl
+++ b/test/mc_test_utils.erl
@@ -10,11 +10,12 @@
 -author("tihon").
 
 %% API
--export([collection/1]).
+-export([collection/2]).
 
-collection(Case) ->
+collection(Mod, Case) ->
   Now = now_to_seconds(os:timestamp()),
   <<(atom_to_binary(?MODULE, utf8))/binary, $-,
+    (atom_to_binary(Mod, utf8))/binary, $-,
     (atom_to_binary(Case, utf8))/binary, $-,
     (list_to_binary(integer_to_list(Now)))/binary>>.
 

--- a/test/mc_worker_api_SUITE.erl
+++ b/test/mc_worker_api_SUITE.erl
@@ -6,7 +6,7 @@
 -include("mongo_protocol.hrl").
 
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 all() ->
   [
@@ -31,7 +31,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(Case, Config) ->
   {ok, Connection} = mc_worker_api:connect([{database, ?config(database, Config)}, {login, <<"user">>}, {password, <<"test">>}, {w_mode, safe}]),
-  [{connection, Connection}, {collection, mc_test_utils:collection(Case)} | Config].
+  [{connection, Connection}, {collection, mc_test_utils:collection(?MODULE, Case)} | Config].
 
 end_per_testcase(_Case, Config) ->
   Connection = ?config(connection, Config),
@@ -65,7 +65,6 @@ insert_and_find(Config) ->
   4 = mc_worker_api:count(Connection, Collection, #{}),
   {ok, TeamsCur} = mc_worker_api:find(Connection, Collection, #{}),
   TeamsFound = mc_cursor:rest(TeamsCur),
-  undefined = process_info(TeamsCur),
   ?assertEqual(Teams, TeamsFound),
 
   {ok, NationalTeamsCur} = mc_worker_api:find(
@@ -134,6 +133,12 @@ insert_and_delete(Config) ->
 
   mc_worker_api:delete_one(Connection, Collection, #{}),
   3 = mc_worker_api:count(Connection, Collection, #{}),
+
+  mc_worker_api:delete_limit(Connection, Collection, #{}, 1),
+  2 = mc_worker_api:count(Connection, Collection, #{}),
+
+  mc_worker_api:delete(Connection, Collection, #{}),
+  0 = mc_worker_api:count(Connection, Collection, #{}),
   Config.
 
 insert_map(Config) ->

--- a/test/switch_db_SUITE.erl
+++ b/test/switch_db_SUITE.erl
@@ -33,7 +33,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(Case, Config) ->
   {ok, Connection} = mc_worker_api:connect([{database, ?config(database, Config)}, {login, <<"user">>}, {password, <<"test">>}, {w_mode, safe}]),
-  [{connection, Connection}, {collection, mc_test_utils:collection(Case)} | Config].
+  [{connection, Connection}, {collection, mc_test_utils:collection(?MODULE, Case)} | Config].
 
 end_per_testcase(_Case, Config) ->
   Connection = ?config(connection, Config),


### PR DESCRIPTION
In MongoDB 3.6, the `OP_MSG` and `OP_COMPRESSED` opcodes were added to
the wired message protocol. `OP_MSG` was added to standardize the
MongoDB message format, and `OP_COMPRESSED` takes things a step
further by compressing the message to increase network efficiency. As
of MongoDB 5.1, the old opcodes were removed, and all messages are
sent with either `OP_MSG` or `OP_COMPRESSED`.

Because this driver did not have the ability to send messages with the
`OP_MSG` opcode, it couldn't be used with any versions of MongoDB
greater than 5.1.

To bring this driver into the modern era, this PR ports over the
changes made in the [emqx fork](https://github.com/emqx/mongodb-erlang/) of this driver to support the`OP_MSG`
opcode.

Additionally, there are some slightly unrelated, but relevant changes
in this PR as well such as fixing some dialyzer errors and updating the
GitHub actions workflow definitions to get the tests up and running again.