### PR TITLE
Fix OP_MSG auth_source handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,12 @@ jobs:
           --health-start-period 15s
     steps:
       - uses: actions/checkout@v4
-      - run: ./rebar3 ct --suite=test/buildinfo_auth_SUITE.erl
+      - run: ./rebar3 ct --suite=test/buildinfo_auth_SUITE.erl --suite=test/op_msg_auth_source_SUITE.erl
         env:
           MONGO_AUTH_HOST: mongo82
           MONGO_AUTH_PORT: "27017"
+          MONGO_AUTH_USER: admin
+          MONGO_AUTH_PASSWORD: admin
       - name: CT Logs
         uses: actions/upload-artifact@v4
         with:

--- a/src/connection/mc_worker.erl
+++ b/src/connection/mc_worker.erl
@@ -141,7 +141,7 @@ process_op_msg_request(Request, From, State) ->
     conn_state = CS,
     net_module = NetModule,
     next_req_fun = Next} = State,
-  Database = CS#conn_state.database,
+  Database = get_database(Request, CS),
   {ok, PacketSize, Id} = mc_worker_logic:make_request(Socket, NetModule, Database, Request),
   UState = need_hibernate(PacketSize, State),
   case get_op_msg_write_concern(Request) of
@@ -266,6 +266,10 @@ get_set_opts_module(Options) ->
 get_database(#getmore{database = undefined}, ConnState) -> ConnState#conn_state.database;
 get_database(#query{database = undefined}, ConnState) -> ConnState#conn_state.database;
 get_database(#ensure_index{database = undefined}, ConnState) -> ConnState#conn_state.database;
+get_database(#op_msg_command{database = undefined}, ConnState) -> ConnState#conn_state.database;
+get_database(#op_msg_write_op{database = undefined}, ConnState) -> ConnState#conn_state.database;
 get_database(#getmore{database = DB}, _) -> DB;
 get_database(#query{database = DB}, _) -> DB;
-get_database(#ensure_index{database = DB}, _) -> DB.
+get_database(#ensure_index{database = DB}, _) -> DB;
+get_database(#op_msg_command{database = DB}, _) -> DB;
+get_database(#op_msg_write_op{database = DB}, _) -> DB.

--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -52,6 +52,7 @@ test_successful_authentication(Config) ->
   %% Connect with correct credentials
   {ok, Conn} = mc_worker_api:connect([
     {database, Database},
+    {auth_source, Database},
     {login, <<"testuser">>},
     {password, <<"testpass">>},
     {host, "localhost"},
@@ -73,6 +74,7 @@ test_failed_authentication_wrong_password(Config) ->
   %% Try to connect with wrong password - should throw an exception
   Result = (catch mc_worker_api:connect([
     {database, Database},
+    {auth_source, Database},
     {login, <<"testuser">>},
     {password, <<"wrongpassword">>},
     {host, "localhost"},
@@ -91,6 +93,7 @@ test_failed_authentication_wrong_user(Config) ->
   %% Try to connect with non-existent user - should throw an exception
   Result = (catch mc_worker_api:connect([
     {database, Database},
+    {auth_source, Database},
     {login, <<"wronguser">>},
     {password, <<"testpass">>},
     {host, "localhost"},
@@ -109,6 +112,7 @@ test_operations_with_auth(Config) ->
   %% Connect with correct credentials
   {ok, Conn} = mc_worker_api:connect([
     {database, Database},
+    {auth_source, Database},
     {login, <<"testuser">>},
     {password, <<"testpass">>},
     {host, "localhost"},

--- a/test/op_msg_auth_source_SUITE.erl
+++ b/test/op_msg_auth_source_SUITE.erl
@@ -1,0 +1,68 @@
+-module(op_msg_auth_source_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+all() ->
+  [
+    auth_source_same_as_database_test,
+    auth_source_differs_from_database_test
+  ].
+
+init_per_suite(Config) ->
+  application:ensure_all_started(mongodb),
+  Host = os:getenv("MONGO_AUTH_HOST", "localhost"),
+  Port = list_to_integer(os:getenv("MONGO_AUTH_PORT", "27021")),
+  case gen_tcp:connect(Host, Port, [], 1000) of
+    {ok, Socket} ->
+      gen_tcp:close(Socket),
+      [
+        {mongo_host, Host},
+        {mongo_port, Port},
+        {mongo_user, bin_env("MONGO_AUTH_USER", "admin")},
+        {mongo_password, bin_env("MONGO_AUTH_PASSWORD", "admin123")}
+        | Config
+      ];
+    {error, _} ->
+      {skip, "Auth-enabled MongoDB not available"}
+  end.
+
+end_per_suite(_Config) ->
+  ok.
+
+auth_source_same_as_database_test(Config) ->
+  Connection = connect(Config, <<"admin">>, <<"admin">>),
+  ?assertEqual(op_msg, mc_worker_pid_info:get_protocol_type(Connection)),
+  {true, PingResult} = mc_worker_api:command(Connection, {<<"ping">>, 1}),
+  ?assertEqual(1.0, maps:get(<<"ok">>, PingResult)),
+  mc_worker_api:disconnect(Connection),
+  ok.
+
+auth_source_differs_from_database_test(Config) ->
+  Connection = connect(Config, <<"test">>, <<"admin">>),
+  ?assertEqual(op_msg, mc_worker_pid_info:get_protocol_type(Connection)),
+  {true, PingResult} = mc_worker_api:command(Connection, {<<"ping">>, 1}),
+  ?assertEqual(1.0, maps:get(<<"ok">>, PingResult)),
+  mc_worker_api:disconnect(Connection),
+  ok.
+
+connect(Config, Database, AuthSource) ->
+  Host = ?config(mongo_host, Config),
+  Port = ?config(mongo_port, Config),
+  User = ?config(mongo_user, Config),
+  Password = ?config(mongo_password, Config),
+  {ok, Connection} = mc_worker_api:connect([
+    {database, Database},
+    {auth_source, AuthSource},
+    {login, User},
+    {password, Password},
+    {host, Host},
+    {port, Port},
+    {use_legacy_protocol, false}
+  ]),
+  Connection.
+
+bin_env(Name, Default) ->
+  list_to_binary(os:getenv(Name, Default)).


### PR DESCRIPTION
  ## Summary

  Fix OP_MSG authentication when `auth_source` differs from `database`.

  The auth request already carried the correct database, but the worker sent OP_MSG commands using the connection default database instead. This caused auth failures when `auth_source` and `database` were different.

  Add regression coverage for both cases and run it in the MongoDB 8 CI job.

  ## Testing

  * `rebar3 ct --suite=test/op_msg_auth_source_SUITE.erl`